### PR TITLE
Suffix the username with Real domain value If not speficied during basic challenge

### DIFF
--- a/lib/basic_and_nego/auth/basic.rb
+++ b/lib/basic_and_nego/auth/basic.rb
@@ -20,9 +20,22 @@ module BasicAndNego
       private
 
       def authenticate(user, password)
-        unless @krb.authenticate(user, password)
-          @logger.debug "Unable to authenticate (401)"
-          @response = unauthorized
+      	#We will firstly try to authenticate the user
+      	#suffixing his username with the realm If not already specified
+      	is_authenticated = false
+      	if !user.include?("@")
+      		user_domain = [user, "@", @realm].join
+      		is_authenticated = @krb.authenticate(user_domain, password)
+	        if !is_authenticated
+	          @logger.debug "Unable to authenticate #{user_domain}, trying with #{user}"
+	        end   
+	    end 
+	    #If authentication with suffix failed, try with user's given information  	
+	    if !is_authenticated
+        	unless @krb.authenticate(user, password)
+          	@logger.debug "Unable to authenticate (401)"
+          	@response = unauthorized
+        	end
         end
       end
 

--- a/lib/basic_and_nego/auth/basic.rb
+++ b/lib/basic_and_nego/auth/basic.rb
@@ -20,23 +20,24 @@ module BasicAndNego
       private
 
       def authenticate(user, password)
-      	#We will firstly try to authenticate the user
-      	#suffixing his username with the realm If not already specified
-      	is_authenticated = false
-      	if !user.include?("@")
-      		user_domain = [user, "@", @realm].join
-      		is_authenticated = @krb.authenticate(user_domain, password)
-	        if !is_authenticated
-	          @logger.debug "Unable to authenticate #{user_domain}, trying with #{user}"
-	        end   
-	    end 
-	    #If authentication with suffix failed, try with user's given information  	
-	    if !is_authenticated
-        	unless @krb.authenticate(user, password)
-          	@logger.debug "Unable to authenticate (401)"
-          	@response = unauthorized
-        	end
-        end
+        #We will firstly try to authenticate the user
+        #suffixing his username with the realm If not already specified
+        is_authenticated = false
+        if !user.include?("@")
+          user_domain = [user, "@", @realm].join
+          is_authenticated = @krb.authenticate(user_domain, password)
+          if !is_authenticated
+            @logger.debug "Unable to authenticate #{user_domain}, trying with #{user}"
+          end   
+        end 
+    
+        #If authentication with suffix failed, try with user's given information  	
+       if !is_authenticated
+         unless @krb.authenticate(user, password)
+           @logger.debug "Unable to authenticate (401)"
+           @response = unauthorized
+         end
+       end
       end
 
     end

--- a/lib/basic_and_nego/auth/basic.rb
+++ b/lib/basic_and_nego/auth/basic.rb
@@ -20,10 +20,24 @@ module BasicAndNego
       private
 
       def authenticate(user, password)
-        unless @krb.authenticate(user, password)
-          @logger.debug "Unable to authenticate (401)"
-          @response = unauthorized
-        end
+        #We will firstly try to authenticate the user
+        #suffixing his username with the realm If not already specified
+        is_authenticated = false
+        if !user.include?("@")
+          user_domain = [user, "@", @realm].join
+          is_authenticated = @krb.authenticate(user_domain, password)
+          if !is_authenticated
+            @logger.debug "Unable to authenticate #{user_domain}, trying with #{user}"
+          end   
+        end 
+    
+        #If authentication with suffix failed, try with user's given information  	
+       if !is_authenticated
+         unless @krb.authenticate(user, password)
+           @logger.debug "Unable to authenticate (401)"
+           @response = unauthorized
+         end
+       end
       end
 
     end

--- a/spec/basic_and_nego/auth/basic_spec.rb
+++ b/spec/basic_and_nego/auth/basic_spec.rb
@@ -22,10 +22,11 @@ describe BasicAndNego::Auth::Basic do
   it "should try authentication against Kerberos in case of Basic" do
     @krb.should_receive(:authenticate).with("fred", "pass").and_return(true)
     @a.process
+    @a.client_name.should == "fred"
   end
 
-  it "should return 'unauthorized' if authentication fails" do 
-    @krb.should_receive(:authenticate).and_return(false)
+  it "should return 'unauthorized' if authentication fails" do
+    @krb.should_receive(:authenticate).and_return(false, false)
     @a.process
     @a.response.should_not be_nil
     @a.response[0].should == 401
@@ -42,5 +43,35 @@ describe BasicAndNego::Auth::Basic do
     @a.process
     @a.client_name.should == "fred"
   end
+  
+  it "should try authentication against Kerberos in case of Basic adding automatically the realm" do
+    @krb.should_receive(:authenticate).and_return(true)
+    @a.process
+    @a.client_name.should == "fred"
+  end  
 
+ 
+end
+
+describe "BasicAndNego::Auth::Basic with specific realm" do
+  
+  before(:each) do 
+    env = {'HTTP_AUTHORIZATION' => "Basic #{::Base64.encode64('fred@customRealm:pass')}"}
+    @realm = "my realm"
+    @keytab = "my keytab"
+    @service = "http/hostname"
+    @logger = BasicAndNego::NullLogger.new
+    @request = BasicAndNego::Request.new(env)
+    @request.should_receive(:credentials).and_return(['fred@customRealm', 'pass'])
+    @krb = double('kerberos').as_null_object
+    BasicAndNego::Auth::Krb.should_receive(:new).with(@logger, @realm, @keytab).and_return(@krb)
+    @a = BasicAndNego::Auth::Basic.new(@request, @logger, @realm, @keytab, @service)
+  end  
+  
+  it "should try authentication against Kerberos in case of Basic" do
+    @krb.should_receive(:authenticate).with("fred@customRealm", "pass").and_return(true)
+    @a.process
+    @a.client_name.should == "fred@customRealm"
+  end
+    
 end

--- a/spec/basic_and_nego/auth/basic_spec.rb
+++ b/spec/basic_and_nego/auth/basic_spec.rb
@@ -24,8 +24,8 @@ describe BasicAndNego::Auth::Basic do
     @a.process
   end
 
-  it "should return 'unauthorized' if authentication fails" do 
-    @krb.should_receive(:authenticate).and_return(false)
+  it "should return 'unauthorized' if authentication fails" do
+    @krb.should_receive(:authenticate).and_return(false, false)
     @a.process
     @a.response.should_not be_nil
     @a.response[0].should == 401
@@ -43,4 +43,27 @@ describe BasicAndNego::Auth::Basic do
     @a.client_name.should == "fred"
   end
 
+ 
+end
+
+describe "BasicAndNego::Auth::Basic with specific realm" do
+  
+  before(:each) do 
+    env = {'HTTP_AUTHORIZATION' => "Basic #{::Base64.encode64('fred@customRealm:pass')}"}
+    @realm = "my realm"
+    @keytab = "my keytab"
+    @service = "http/hostname"
+    @logger = BasicAndNego::NullLogger.new
+    @request = BasicAndNego::Request.new(env)
+    @request.should_receive(:credentials).and_return(['fred@customRealm', 'pass'])
+    @krb = double('kerberos').as_null_object
+    BasicAndNego::Auth::Krb.should_receive(:new).with(@logger, @realm, @keytab).and_return(@krb)
+    @a = BasicAndNego::Auth::Basic.new(@request, @logger, @realm, @keytab, @service)
+  end  
+  
+  it "should try authentication against Kerberos in case of Basic" do
+    @krb.should_receive(:authenticate).with("fred@customRealm", "pass").and_return(true)
+    @a.process
+  end
+    
 end


### PR DESCRIPTION
Sometimes we need to have the realm added as suffix of username like mbridard@<REALM> instead of mbridard to valdiate a Basic authentication.

This commit add this possibility keeping also the standard basic way.
