### PR TITLE
Scheme type can be either string or symbol

### DIFF
--- a/lib/basic_and_nego/request.rb
+++ b/lib/basic_and_nego/request.rb
@@ -24,7 +24,7 @@ module BasicAndNego
     private
 
     def supported_auth?
-      [:basic, :negotiate].include? scheme
+      %w(basic negotiate).include? scheme.to_s
     end
   end
 end


### PR DESCRIPTION
In my setup basic was symbol and negotiate was string. This makes sure
that both schemes are supported whenever rack changes its mind.
